### PR TITLE
Use classifiers to specify the license.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,8 +8,10 @@ setup(
     author='cormoran',
     author_email='cormoran707@gmail.com',
     url='https://github.com/cormoran/config_argparse',
-    license='mit',
     packages=find_packages(exclude=('tests')),
     install_requires=[],
     test_suite='tests',
+    classifiers=[
+        'License :: OSI Approved :: MIT License',
+    ],
 )


### PR DESCRIPTION
Classifiers are a standard way of specifying a license, and make it easy
for automated tools to properly detect the license of the package.

The "license" field should only be used if the license has no
corresponding Trove classifier.